### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ SPGooglePlacesAutocomplete requires a deployment target >= iOS 5.0.
 Instantiate a new SPGooglePlacesAutocompleteQuery and fill in the properties you'd like to specify.
 
 ``` objective-c
-#import "SPGooglePlacesAutocompleteQuery.h"
+# import "SPGooglePlacesAutocompleteQuery.h"
 
 ...
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
